### PR TITLE
Fix some bugs with default assignments, improve specs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+v2.1.6
+Fixed an issue assigning defaults to already persisted classes, and fixed main spec
+
 v2.1.5
 Fixed issue with casting nil to a string
 

--- a/lib/super_serial/entry.rb
+++ b/lib/super_serial/entry.rb
@@ -51,7 +51,7 @@ module SuperSerial
       end
 
       def set_default_value_lambda(_name, _value)
-        ->{ set_super_serial_value(_value, _name) if entry_is_serialized?(_name) and new_record? }
+        ->{ set_super_serial_value(_value, _name) if entry_is_serialized?(_name) and entry_needs_default?(_name) }
       end
   end
 end

--- a/lib/super_serial/super_serialize.rb
+++ b/lib/super_serial/super_serialize.rb
@@ -46,4 +46,8 @@ module SuperSerial #like, for srs
   def entry_is_serialized?(entry_name)
     entry_name.to_sym.in?(self.class.serialized_entry_names)
   end
+
+  def entry_needs_default?(_name)
+    send(self.class.super_serial_column_name).send(_name).nil?
+  end
 end

--- a/lib/super_serial/version.rb
+++ b/lib/super_serial/version.rb
@@ -1,3 +1,3 @@
 module SuperSerial
-  VERSION = "2.1.5"
+  VERSION = "2.1.6"
 end

--- a/spec/super_serial_spec.rb
+++ b/spec/super_serial_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe SuperSerial do
+  around(:each) do
+    ActiveRecord::Base.connection.close
+  end
+
+  after(:each) do
+    Object.send(:remove_const, :ClassToSuperSerialize)
+  end
+
   it 'cannot be included in non AR classes' do
     expect {
       class NonActiveRecord
@@ -20,6 +28,29 @@ describe SuperSerial do
     expect { ClassToSuperSerialize.create }.not_to raise_exception(Exception)
     ClassToSuperSerialize.super_serialize :foo_column, bar_attribute: true
     expect { ClassToSuperSerialize.create }.not_to raise_exception(Exception)
+  end
+
+  it 'handles updates to the invocation of .super_serialize for persisted objects that have super serial added to them' do
+    ClassToSuperSerialize.create
+    ClassToSuperSerialize.super_serialize :foo_column, foo_attribute: 'DEFAULT'
+    ClassToSuperSerialize.new.foo_attribute.should eql('DEFAULT')
+    ClassToSuperSerialize.super_serialize :foo_column, bar_attribute: false
+    ClassToSuperSerialize.new.bar_attribute.should eql(false)
+  end
+
+  it 'handles updates to the invocation of .super_serialize for persisted objects' do
+    ClassToSuperSerialize.super_serialize :foo_column, foo_attribute: 'DEFAULT'
+    ClassToSuperSerialize.create
+    ClassToSuperSerialize.new.foo_attribute.should eql('DEFAULT')
+    ClassToSuperSerialize.super_serialize :foo_column, bar_attribute: false
+    ClassToSuperSerialize.new.bar_attribute.should eql(false)
+  end
+
+  it 'handles updates to the invocation of .super_serialize for persisted objects' do
+    ClassToSuperSerialize.super_serialize :foo_column, foo_attribute: 'DEFAULT'
+    ClassToSuperSerialize.new.foo_attribute.should eql('DEFAULT')
+    ClassToSuperSerialize.super_serialize :foo_column, bar_attribute: false
+    ClassToSuperSerialize.new.bar_attribute.should eql(false)
   end
 
   context '.super_serialize' do


### PR DESCRIPTION
Three fixes: 
- fixes an issue where a class has been persisted with super serial data and when you add an entry to super serialize, the new entry does not show up until the class is saved again 
- fixes the case where a class is persisted without super serialize and then it is added later
- fixes the spec for super serialize to clean itself up between tests. Since there is so much class-based meta, we need to clear the db table and reload the class to ensure the tests are isolated.
