### PR TITLE
Change the way the super serialized column responds to #to_json.

### DIFF
--- a/lib/super_serial.rb
+++ b/lib/super_serial.rb
@@ -4,6 +4,7 @@ require "super_serial/version"
 require 'super_serial/super_serialize'
 require 'super_serial/value'
 require 'super_serial/entry'
+require 'super_serial/data_struct'
 
 module SuperSerial
   extend ActiveSupport::Concern

--- a/lib/super_serial/data_struct.rb
+++ b/lib/super_serial/data_struct.rb
@@ -1,0 +1,6 @@
+class DataStruct < OpenStruct
+  def to_json
+    json = super
+    JSON.parse(json)['table'].to_json
+  end
+end

--- a/lib/super_serial/super_serialize.rb
+++ b/lib/super_serial/super_serialize.rb
@@ -25,7 +25,7 @@ module SuperSerial #like, for srs
       self.super_serial_column_name = _column_name.to_s
       self.serialized_entry_names   = entries.keys
 
-      serialize super_serial_column_name.to_sym, OpenStruct
+      serialize super_serial_column_name.to_sym, DataStruct
 
       entries.each_pair do |entry_name, default_value|
         SuperSerial::Entry.new(entry_name, default_value, self, super_serial_column_name)

--- a/spec/data_struct_spec.rb
+++ b/spec/data_struct_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe DataStruct do
+  let(:data_struct) { DataStruct.new(name: 'my_struct') }
+
+  describe '#to_json' do
+    subject { JSON.parse(data_struct.to_json) }
+    it { should have_key('name') }
+    it { should have_value('my_struct') }
+  end
+end

--- a/spec/super_serial_spec.rb
+++ b/spec/super_serial_spec.rb
@@ -49,7 +49,7 @@ describe SuperSerial do
 
   context '.super_serialize' do
     it 'serializes the data given in the column given by the first argument' do
-      ClassToSuperSerialize.should_receive(:serialize).with(:foo_column, OpenStruct)
+      ClassToSuperSerialize.should_receive(:serialize).with(:foo_column, DataStruct)
       ClassToSuperSerialize.super_serialize :foo_column, name: 'Billy'
     end
 


### PR DESCRIPTION
## Summary 
From the pivotal story: 

`OpenStruct#to_json` responds with an undesirable structure (the key-value pairs representing the object's 'data' are in a key named table instead of returned as on object themselves). We should subclass `OpenStruct` and override its `#to_json` method so we can respond with the pertinent data itself. 

Ex: 
```
o_struct = OpenStruct.new(name: 'my_struct')
 => #<OpenStruct name="my_struct">

o_struct.to_json
 => "{\"table\":{\"name\":\"my_struct\"}}" 
```
We want this behavior:
*DataStruct is a new subclass of OpenStruct*
```
data_struct = DataStruct.new(name: 'my_struct')
 => #<DataStruct name="my_struct">

data_struct.to_json
 => "{\"name\":\"my_struct\"}"
``` 

The reason this response is important is for JSON serialization considerations. If you use `ActiveModel::Serializer` (or any other method of serialization that relies on `#to_json`) to serialize the data from a `super_serial` enabled column, without this update your structure would have the undesirable `table` key. With the update, `#to_json` will provide the object for consumption by `ActiveModel::Serializer` nicely.