### PR TITLE
Add support for Rails 4 ActiveRecord::Base classes

### DIFF
--- a/lib/super_serial/entry.rb
+++ b/lib/super_serial/entry.rb
@@ -16,7 +16,7 @@ module SuperSerial
 
       def generate
         define_getter_and_setter
-        klass.attr_accessible name
+        klass.attr_accessible name if klass.respond_to?(:attr_accessible)
         define_boolean_accessor if !!value == value
         set_callbacks
       end

--- a/spec/entry_spec.rb
+++ b/spec/entry_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/rails_4_model'
 
 describe SuperSerial::Entry do
   before :all do
@@ -23,6 +24,11 @@ describe SuperSerial::Entry do
   context 'on the abstract class' do
     before :each do
       @instance = EntryTest.new
+    end
+
+    it 'does not exception without attr_accessible defined' do
+      class FooClass < Rails4Model; end
+      expect(->{ SuperSerial::Entry.new('name', 'Ben', FooClass, :foo_column) }).not_to raise_error
     end
 
     it 'defines a getter and setter' do

--- a/spec/support/rails_4_model.rb
+++ b/spec/support/rails_4_model.rb
@@ -1,0 +1,8 @@
+class Rails4Model
+  # this is just a stub class
+  def self.after_initialize(*args)
+  end
+
+  def self.before_validation(*args)
+  end
+end


### PR DESCRIPTION
Rails 4 models explode when you attempt to use SuperSerial because of the call to .attr_accessible, which was removed. Just need to check if it's defined before calling it.
